### PR TITLE
perf: basic optimizations

### DIFF
--- a/benchmarks/string.ts
+++ b/benchmarks/string.ts
@@ -1,0 +1,23 @@
+import { FixedUTF8String } from "../types/string/mod.ts";
+
+const stringThing = new FixedUTF8String(12);
+
+const ab = new TextEncoder().encode("Hello World!").buffer;
+const dt = new DataView(ab);
+
+
+Deno.bench("no-op", () => {});
+
+Deno.bench({
+  name: "Read",
+  fn: () => {
+    stringThing.read(dt);
+  }
+});
+
+Deno.bench({
+  name: "Write",
+  fn: () => {
+    stringThing.write( "hello world!", dt);
+  }
+});

--- a/benchmarks/string.ts
+++ b/benchmarks/string.ts
@@ -5,19 +5,18 @@ const stringThing = new FixedUTF8String(12);
 const ab = new TextEncoder().encode("Hello World!").buffer;
 const dt = new DataView(ab);
 
-
 Deno.bench("no-op", () => {});
 
 Deno.bench({
   name: "Read",
   fn: () => {
     stringThing.read(dt);
-  }
+  },
 });
 
 Deno.bench({
   name: "Write",
   fn: () => {
-    stringThing.write( "hello world!", dt);
-  }
+    stringThing.write("hello world!", dt);
+  },
 });

--- a/benchmarks/tuple.ts
+++ b/benchmarks/tuple.ts
@@ -2,22 +2,21 @@ import { Tuple } from "../types/tuple/mod.ts";
 import { u32 } from "../types/primitive/u32.ts";
 
 const benchTuple = new Tuple([u32, u32]);
-const u32arr = new Uint32Array([2,4]);
+const u32arr = new Uint32Array([2, 4]);
 const dt = new DataView(u32arr.buffer);
-
 
 Deno.bench("no-op", () => {});
 
 Deno.bench({
   name: "Read",
   fn: () => {
-    benchTuple.read(dt)
-  }
-})
+    benchTuple.read(dt);
+  },
+});
 
 Deno.bench({
   name: "Write",
   fn: () => {
-    benchTuple.write( [4, 2], dt)
-  }
-})
+    benchTuple.write([4, 2], dt);
+  },
+});

--- a/benchmarks/tuple.ts
+++ b/benchmarks/tuple.ts
@@ -9,7 +9,7 @@ const dt = new DataView(u32arr.buffer);
 Deno.bench("no-op", () => {});
 
 Deno.bench({
-  name: "Original",
+  name: "Read",
   fn: () => {
     benchTuple.read(dt)
   }

--- a/benchmarks/tuple.ts
+++ b/benchmarks/tuple.ts
@@ -1,0 +1,23 @@
+import { Tuple } from "../types/tuple/mod.ts";
+import { u32 } from "../types/primitive/u32.ts";
+
+const benchTuple = new Tuple([u32, u32]);
+const u32arr = new Uint32Array([2,4]);
+const dt = new DataView(u32arr.buffer);
+
+
+Deno.bench("no-op", () => {});
+
+Deno.bench({
+  name: "Original",
+  fn: () => {
+    benchTuple.read(dt)
+  }
+})
+
+Deno.bench({
+  name: "Write",
+  fn: () => {
+    benchTuple.write( [4, 2], dt)
+  }
+})

--- a/types/string/mod.ts
+++ b/types/string/mod.ts
@@ -12,7 +12,7 @@ export class FixedUTF8String implements SizedType<string> {
 
   read(dataView: DataView, byteOffset = 0): string {
     return decoder.decode(
-      dataView.buffer.slice(byteOffset, byteOffset + this.byteLength),
+      new Uint8Array(dataView.buffer, byteOffset, byteOffset + this.byteLength),
     );
   }
 

--- a/types/struct/struct.ts
+++ b/types/struct/struct.ts
@@ -41,8 +41,12 @@ export class Struct<
   }
 
   write(value: V, dataView: DataView, byteOffset = 0) {
-    for (const [key, [typeOffset, type]] of Object.entries(this.typeRecord)) {
-      type.write(value[key], dataView, byteOffset + typeOffset);
+    const keys = Object.keys(this.typeRecord);
+    const len = keys.length;
+    for (let i = 0; i < len; i++) {
+      const key = keys[i];
+      const [offset, type] = this.typeRecord[key];
+      type.write(value[key], dataView, byteOffset + offset);
     }
   }
 

--- a/types/struct/struct.ts
+++ b/types/struct/struct.ts
@@ -34,7 +34,10 @@ export class Struct<
     for (let i = 0; i < len; i++) {
       const k = keys[i];
       const [offset, type] = this.typeRecord[k];
-      object[k as keyof V] = type.read(dataView, byteOffset + offset) as V[keyof V];
+      object[k as keyof V] = type.read(
+        dataView,
+        byteOffset + offset,
+      ) as V[keyof V];
     }
 
     return object;

--- a/types/struct/struct.ts
+++ b/types/struct/struct.ts
@@ -27,13 +27,17 @@ export class Struct<
   }
 
   read(dataView: DataView, byteOffset = 0): V {
-    const object: Record<string, unknown> = {};
+    const keys = Object.keys(this.typeRecord);
+    const len = keys.length;
+    const object = {} as V;
 
-    for (const [key, [typeOffset, type]] of Object.entries(this.typeRecord)) {
-      object[key] = type.read(dataView, byteOffset + typeOffset);
+    for (let i = 0; i < len; i++) {
+      const k = keys[i];
+      const [offset, type] = this.typeRecord[k];
+      object[k as keyof V] = type.read(dataView, byteOffset + offset) as V[keyof V];
     }
 
-    return object as V;
+    return object;
   }
 
   write(value: V, dataView: DataView, byteOffset = 0) {

--- a/types/tuple/mod.ts
+++ b/types/tuple/mod.ts
@@ -37,7 +37,6 @@ export class Tuple<
       const [typeOffset, type] = this.typeOffsets[i];
       type.write(value[i], dataView, byteOffset + typeOffset);
     }
-
   }
 
   view(dataView: DataView, byteOffset = 0): V {

--- a/types/tuple/mod.ts
+++ b/types/tuple/mod.ts
@@ -32,10 +32,12 @@ export class Tuple<
   }
 
   write(value: V, dataView: DataView, byteOffset = 0) {
-    let i = 0;
-    for (const [typeOffset, type] of this.typeOffsets) {
-      type.write(value[i++], dataView, byteOffset + typeOffset);
+    const len = this.typeOffsets.length;
+    for (let i = 0; i < len; i++) {
+      const [typeOffset, type] = this.typeOffsets[i];
+      type.write(value[i], dataView, byteOffset + typeOffset);
     }
+
   }
 
   view(dataView: DataView, byteOffset = 0): V {

--- a/types/tuple/mod.ts
+++ b/types/tuple/mod.ts
@@ -21,12 +21,13 @@ export class Tuple<
   }
 
   read(dataView: DataView, byteOffset = 0): V {
-    const tuple = [];
+    const len = this.typeOffsets.length;
 
-    for (const [typeOffset, type] of this.typeOffsets) {
-      tuple.push(type.read(dataView, byteOffset + typeOffset));
+    const tuple = new Array(len);
+    for (let i = 0; i < len; i++) {
+      const [typeOffset, type] = this.typeOffsets[i];
+      tuple[i] = type.read(dataView, byteOffset + typeOffset);
     }
-
     return tuple as V;
   }
 


### PR DESCRIPTION
Most of the benchmarks haven't decreased by much. But p995 and max have been reduces by a lot. Which should also help with scenario's where these functions are not jit compiled (--jitless or in cold paths)
### Struct Read
```
Original  119.36 ns/iter  (113.08 ns … 477.2 ns) 119.72 ns 139.11 ns 141.89 ns
Opt        96.91 ns/iter  (92.87 ns … 111.48 ns)  98.65 ns  102.8 ns 107.44 ns
```

### Struct Write
```
Original   99.87 ns/iter  (95.88 ns … 159.56 ns) 101.34 ns 113.85 ns  147.5 ns
Opt        68.71 ns/iter     (64 ns … 138.86 ns)  70.36 ns  81.27 ns 103.76 ns
```

### String Read
```
Original     1.28 µs/iter   (883.98 ns … 2.19 µs)   1.42 µs   2.19 µs   2.19 µs
Opt        178.88 ns/iter (174.17 ns … 315.51 ns) 180.14 ns 192.44 ns 247.79 ns
```

### Tuple Read
```
Original    35.36 ns/iter   (30.7 ns … 105.51 ns)  36.08 ns  67.82 ns  80.11 ns
Opt         20.99 ns/iter   (19.83 ns … 52.47 ns)  20.63 ns  26.84 ns  29.62 ns
```

### Tuple Write
```
Original    27.94 ns/iter   (26.97 ns … 65.92 ns)  27.92 ns   31.8 ns   43.1 ns
Opt         25.88 ns/iter   (24.34 ns … 37.55 ns)  25.95 ns  26.28 ns  26.65 ns
```