### PR TITLE
refactor: referenced `byteOffset` in `TypeOptions`

### DIFF
--- a/types/leb128/i32leb128.ts
+++ b/types/leb128/i32leb128.ts
@@ -1,37 +1,44 @@
-import type { Type } from "../types.ts";
+import type { ReadOptions, Type, WriteOptions } from "../types.ts";
 
 const SEGMENT_BITS = 0x7F;
 const CONTINUE_BIT = 0x80;
 
 export class I32LEB128 implements Type<number> {
-  read(dataView: DataView, byteOffset = 0): number {
+  read(dataView: DataView, options: ReadOptions = {}): number {
+    options.byteOffset ??= 0;
+
     let value = 0, position = 0;
     while (true) {
-      const currentByte = dataView.getInt8(byteOffset);
+      const currentByte = dataView.getInt8(options.byteOffset);
       value |= (currentByte & SEGMENT_BITS) << position;
 
       if ((currentByte & CONTINUE_BIT) === 0) break;
 
       position += 7;
-      byteOffset++;
+      options.byteOffset++;
 
       if (position >= 32) {
         throw new TypeError("I32LEB128 cannot exceed 32 bits in length");
       }
     }
 
+    options.byteOffset++;
+
     return value;
   }
 
-  write(value: number, dataView: DataView, byteOffset = 0): void {
+  write(value: number, dataView: DataView, options: WriteOptions = {}): void {
+    options.byteOffset ??= 0;
+
     while (true) {
       if ((value & ~SEGMENT_BITS) === 0) {
-        dataView.setInt8(byteOffset, value);
+        dataView.setInt8(options.byteOffset, value);
+        options.byteOffset++;
         return;
       }
 
-      dataView.setInt8(byteOffset, value & SEGMENT_BITS | CONTINUE_BIT);
-      byteOffset++;
+      dataView.setInt8(options.byteOffset, value & SEGMENT_BITS | CONTINUE_BIT);
+      options.byteOffset++;
       value >>>= 7;
     }
   }

--- a/types/leb128/i32leb128.ts
+++ b/types/leb128/i32leb128.ts
@@ -1,13 +1,15 @@
 import type { ReadOptions, Type, WriteOptions } from "../types.ts";
 
-const SEGMENT_BITS = 0x7F;
+const SEGMENT_BITS = 0x7f;
 const CONTINUE_BIT = 0x80;
 
 export class I32LEB128 implements Type<number> {
-  read(dataView: DataView, options: ReadOptions = {}): number {
+  read(dataView: DataView, options?: ReadOptions): number {
+    options ??= {};
     options.byteOffset ??= 0;
 
-    let value = 0, position = 0;
+    let value = 0,
+      position = 0;
     while (true) {
       const currentByte = dataView.getInt8(options.byteOffset);
       value |= (currentByte & SEGMENT_BITS) << position;
@@ -18,7 +20,7 @@ export class I32LEB128 implements Type<number> {
       options.byteOffset++;
 
       if (position >= 32) {
-        throw new TypeError("I32LEB128 cannot exceed 32 bits in length");
+        throw new RangeError("I32LEB128 cannot exceed 32 bits in length");
       }
     }
 
@@ -27,7 +29,8 @@ export class I32LEB128 implements Type<number> {
     return value;
   }
 
-  write(value: number, dataView: DataView, options: WriteOptions = {}): void {
+  write(value: number, dataView: DataView, options?: WriteOptions): void {
+    options ??= {};
     options.byteOffset ??= 0;
 
     while (true) {
@@ -37,7 +40,10 @@ export class I32LEB128 implements Type<number> {
         return;
       }
 
-      dataView.setInt8(options.byteOffset, value & SEGMENT_BITS | CONTINUE_BIT);
+      dataView.setInt8(
+        options.byteOffset,
+        (value & SEGMENT_BITS) | CONTINUE_BIT
+      );
       options.byteOffset++;
       value >>>= 7;
     }

--- a/types/leb128/i32leb128.ts
+++ b/types/leb128/i32leb128.ts
@@ -42,7 +42,7 @@ export class I32LEB128 implements Type<number> {
 
       dataView.setInt8(
         options.byteOffset,
-        (value & SEGMENT_BITS) | CONTINUE_BIT
+        (value & SEGMENT_BITS) | CONTINUE_BIT,
       );
       options.byteOffset++;
       value >>>= 7;

--- a/types/leb128/i32leb128_test.ts
+++ b/types/leb128/i32leb128_test.ts
@@ -4,31 +4,43 @@ import { i32leb128 } from "./mod.ts";
 Deno.test("i32leb128", async ({ step }) => {
   await step("read", async ({ step }) => {
     await step("positive", () => {
+      const options = { byteOffset: 0 };
       let data = Uint8Array.of(127);
-      let result = i32leb128.read(new DataView(data.buffer));
+      let result = i32leb128.read(new DataView(data.buffer), options);
       assertEquals(result, 127);
+      assertEquals(options.byteOffset, 1);
 
+      options.byteOffset = 0;
       data = Uint8Array.of(128, 1);
-      result = i32leb128.read(new DataView(data.buffer));
+      result = i32leb128.read(new DataView(data.buffer), options);
       assertEquals(result, 128);
+      assertEquals(options.byteOffset, 2);
 
+      options.byteOffset = 0;
       data = Uint8Array.of(221, 199, 1);
-      result = i32leb128.read(new DataView(data.buffer));
+      result = i32leb128.read(new DataView(data.buffer), options);
       assertEquals(result, 25565);
+      assertEquals(options.byteOffset, 3);
 
+      options.byteOffset = 0;
       data = Uint8Array.of(255, 255, 255, 255, 7);
-      result = i32leb128.read(new DataView(data.buffer));
+      result = i32leb128.read(new DataView(data.buffer), options);
       assertEquals(result, 2147483647);
+      assertEquals(options.byteOffset, 5);
     });
 
     await step("negative", () => {
+      const options = { byteOffset: 0 };
       let data = Uint8Array.of(255, 255, 255, 255, 15);
-      let result = i32leb128.read(new DataView(data.buffer));
+      let result = i32leb128.read(new DataView(data.buffer), options);
       assertEquals(result, -1);
+      assertEquals(options.byteOffset, 5);
 
+      options.byteOffset = 0;
       data = Uint8Array.of(128, 128, 128, 128, 8);
-      result = i32leb128.read(new DataView(data.buffer));
+      result = i32leb128.read(new DataView(data.buffer), options);
       assertEquals(result, -2147483648);
+      assertEquals(options.byteOffset, 5);
     });
 
     await step("bad", () => {
@@ -44,31 +56,43 @@ Deno.test("i32leb128", async ({ step }) => {
 
   await step("write", async ({ step }) => {
     await step("positive", () => {
+      const options = { byteOffset: 0 };
       let data = new Uint8Array(1);
-      i32leb128.write(127, new DataView(data.buffer));
+      i32leb128.write(127, new DataView(data.buffer), options);
       assertEquals(data, Uint8Array.of(127));
+      assertEquals(options.byteOffset, 1);
 
+      options.byteOffset = 0;
       data = new Uint8Array(2);
-      i32leb128.write(128, new DataView(data.buffer));
+      i32leb128.write(128, new DataView(data.buffer), options);
       assertEquals(data, Uint8Array.of(128, 1));
+      assertEquals(options.byteOffset, 2);
 
+      options.byteOffset = 0;
       data = new Uint8Array(3);
-      i32leb128.write(25565, new DataView(data.buffer));
+      i32leb128.write(25565, new DataView(data.buffer), options);
       assertEquals(data, Uint8Array.of(221, 199, 1));
+      assertEquals(options.byteOffset, 3);
 
+      options.byteOffset = 0;
       data = new Uint8Array(5);
-      i32leb128.write(2147483647, new DataView(data.buffer));
+      i32leb128.write(2147483647, new DataView(data.buffer), options);
       assertEquals(data, Uint8Array.of(255, 255, 255, 255, 7));
+      assertEquals(options.byteOffset, 5);
     });
 
     await step("negative", () => {
+      const options = { byteOffset: 0 };
       let data = new Uint8Array(5);
-      i32leb128.write(-1, new DataView(data.buffer));
+      i32leb128.write(-1, new DataView(data.buffer), options);
       assertEquals(data, Uint8Array.of(255, 255, 255, 255, 15));
+      assertEquals(options.byteOffset, 5);
 
+      options.byteOffset = 0;
       data = new Uint8Array(5);
-      i32leb128.write(-2147483648, new DataView(data.buffer));
+      i32leb128.write(-2147483648, new DataView(data.buffer), options);
       assertEquals(data, Uint8Array.of(128, 128, 128, 128, 8));
+      assertEquals(options.byteOffset, 5);
     });
 
     await step("i32 max", () => {

--- a/types/leb128/i64leb128.ts
+++ b/types/leb128/i64leb128.ts
@@ -2,23 +2,26 @@ import type { ReadOptions, Type, WriteOptions } from "../types.ts";
 import { read, write } from "./_i64leb128.ts";
 
 export class I64LEB128 implements Type<bigint> {
-  read(dataView: DataView, options: ReadOptions = {}): bigint {
+  read(dataView: DataView, options?: ReadOptions): bigint {
+    options ??= {};
     options.byteOffset ??= 0;
 
     try {
-      const [value, _bytesRead] = read(
+      const [value, bytesRead] = read(
         new Uint8Array(
           dataView.buffer,
           dataView.byteOffset + options.byteOffset,
         ),
       );
+      options.byteOffset += bytesRead;
       return value;
     } catch {
-      throw new RangeError("I64LEB128 is too large");
+      throw new RangeError("I64LEB128 cannot exceed 64 bits in length");
     }
   }
 
-  write(value: bigint, dataView: DataView, options: WriteOptions = {}): void {
+  write(value: bigint, dataView: DataView, options?: WriteOptions): void {
+    options ??= {};
     options.byteOffset ??= 0;
 
     const view = write(value);
@@ -28,6 +31,7 @@ export class I64LEB128 implements Type<bigint> {
       dataView.byteLength,
     );
     writeView.set(view, 0);
+    options.byteOffset += view.byteLength;
   }
 }
 

--- a/types/leb128/i64leb128.ts
+++ b/types/leb128/i64leb128.ts
@@ -1,11 +1,16 @@
-import type { Type } from "../types.ts";
+import type { ReadOptions, Type, WriteOptions } from "../types.ts";
 import { read, write } from "./_i64leb128.ts";
 
 export class I64LEB128 implements Type<bigint> {
-  read(dataView: DataView, byteOffset = 0): bigint {
+  read(dataView: DataView, options: ReadOptions = {}): bigint {
+    options.byteOffset ??= 0;
+
     try {
       const [value, _bytesRead] = read(
-        new Uint8Array(dataView.buffer, dataView.byteOffset + byteOffset),
+        new Uint8Array(
+          dataView.buffer,
+          dataView.byteOffset + options.byteOffset,
+        ),
       );
       return value;
     } catch {
@@ -13,11 +18,13 @@ export class I64LEB128 implements Type<bigint> {
     }
   }
 
-  write(value: bigint, dataView: DataView, byteOffset = 0): void {
+  write(value: bigint, dataView: DataView, options: WriteOptions = {}): void {
+    options.byteOffset ??= 0;
+
     const view = write(value);
     const writeView = new Uint8Array(
       dataView.buffer,
-      dataView.byteOffset + byteOffset,
+      dataView.byteOffset + options.byteOffset,
       dataView.byteLength,
     );
     writeView.set(view, 0);

--- a/types/leb128/i64leb128_test.ts
+++ b/types/leb128/i64leb128_test.ts
@@ -4,20 +4,31 @@ import { i64leb128 } from "./i64leb128.ts";
 Deno.test("i64leb128", async ({ step }) => {
   await step("read", async ({ step }) => {
     await step("positive", () => {
+      const options = { byteOffset: 0 };
       assertEquals(
-        i64leb128.read(new DataView(Uint8Array.of(0x01).buffer)),
+        i64leb128.read(new DataView(Uint8Array.of(0x01).buffer), options),
         1n,
       );
+      assertEquals(options.byteOffset, 1);
+
+      options.byteOffset = 0;
       assertEquals(
-        i64leb128.read(new DataView(Uint8Array.of(0xff, 0x01).buffer)),
+        i64leb128.read(new DataView(Uint8Array.of(0xff, 0x01).buffer), options),
         255n,
       );
+      assertEquals(options.byteOffset, 2);
+
+      options.byteOffset = 0;
       assertEquals(
         i64leb128.read(
           new DataView(Uint8Array.of(0xff, 0xff, 0xff, 0xff, 0x07).buffer),
+          options,
         ),
         2147483647n,
       );
+      assertEquals(options.byteOffset, 5);
+
+      options.byteOffset = 0;
       assertEquals(
         i64leb128.read(
           new DataView(
@@ -33,12 +44,15 @@ Deno.test("i64leb128", async ({ step }) => {
               0x7f,
             ).buffer,
           ),
+          options,
         ),
         9223372036854775807n,
       );
+      assertEquals(options.byteOffset, 9);
     });
 
     await step("negative", () => {
+      const options = { byteOffset: 0 };
       assertEquals(
         i64leb128.read(
           new DataView(
@@ -55,9 +69,13 @@ Deno.test("i64leb128", async ({ step }) => {
               0x01,
             ).buffer,
           ),
+          options,
         ),
         -1n,
       );
+      assertEquals(options.byteOffset, 10);
+
+      options.byteOffset = 0;
       assertEquals(
         i64leb128.read(
           new DataView(
@@ -74,9 +92,13 @@ Deno.test("i64leb128", async ({ step }) => {
               0x01,
             ).buffer,
           ),
+          options,
         ),
         -2147483648n,
       );
+      assertEquals(options.byteOffset, 10);
+
+      options.byteOffset = 0;
       assertEquals(
         i64leb128.read(
           new DataView(
@@ -93,9 +115,11 @@ Deno.test("i64leb128", async ({ step }) => {
               0x01,
             ).buffer,
           ),
+          options,
         ),
         -9223372036854775808n,
       );
+      assertEquals(options.byteOffset, 10);
     });
 
     await step("bad", () => {
@@ -123,16 +147,19 @@ Deno.test("i64leb128", async ({ step }) => {
 
   await step("write", async ({ step }) => {
     await step("positive", () => {
-      const buff = new Uint8Array(1);
-      i64leb128.write(10n, new DataView(buff.buffer));
-      assertEquals(buff, Uint8Array.of(10));
+      const options = { byteOffset: 0 };
+      const data = new Uint8Array(1);
+      i64leb128.write(10n, new DataView(data.buffer), options);
+      assertEquals(data, Uint8Array.of(10));
+      assertEquals(options.byteOffset, 1);
     });
 
     await step("negative", () => {
-      const buff = new Uint8Array(10);
-      i64leb128.write(-1n, new DataView(buff.buffer));
+      const options = { byteOffset: 0 };
+      const data = new Uint8Array(10);
+      i64leb128.write(-1n, new DataView(data.buffer), options);
       assertEquals(
-        buff,
+        data,
         Uint8Array.of(
           0xff,
           0xff,
@@ -146,6 +173,7 @@ Deno.test("i64leb128", async ({ step }) => {
           0x01,
         ),
       );
+      assertEquals(options.byteOffset, 10);
     });
   });
 });

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,7 +1,16 @@
+export interface TypeOptions {
+  byteOffset?: number;
+}
+
+export type ReadOptions = TypeOptions;
+export type WriteOptions = TypeOptions;
+export type ViewOptions = TypeOptions;
+
 export type InnerType<T> = T extends Type<infer I> ? I : never;
+
 export interface Type<T> {
-  read(dataView: DataView, byteOffset?: number): T;
-  write(value: T, dataView: DataView, byteOffset?: number): void;
+  read(dataView: DataView, options?: ReadOptions): T;
+  write(value: T, dataView: DataView, options?: WriteOptions): void;
 }
 
 export interface SizedType<T> extends Type<T> {
@@ -13,5 +22,5 @@ export interface AlignedType<T> extends SizedType<T> {
 }
 
 export interface ViewableType<T> {
-  view(dataView: DataView, byteOffset?: number): T;
+  view(dataView: DataView, options?: ViewOptions): T;
 }


### PR DESCRIPTION
This is a pretty large and wip refactor which moves the `byteOffset` into an object, allowing types to be dynamically sized by mutating the referenced `byteOffset` property. This is useful and required for features like unsized structs and allowing them to contain null terminated string and other dynamically sized types.

Discussed with @MierenManz on discord.