### PR TITLE
fix: issue with negative `BitFlags32` after a bitwise op

### DIFF
--- a/types/bitflags/bitflags32.ts
+++ b/types/bitflags/bitflags32.ts
@@ -16,7 +16,7 @@ export class BitFlags32<
     const ret: Record<string, boolean> = {};
 
     for (const [key, flag] of Object.entries(this.flags)) {
-      ret[key] = !!(flags & flag);
+      ret[key] = Boolean(flags & flag);
     }
 
     return ret as V;

--- a/types/bitflags/bitflags32.ts
+++ b/types/bitflags/bitflags32.ts
@@ -16,7 +16,7 @@ export class BitFlags32<
     const ret: Record<string, boolean> = {};
 
     for (const [key, flag] of Object.entries(this.flags)) {
-      ret[key] = (flags & flag) === flag;
+      ret[key] = !!(flags & flag);
     }
 
     return ret as V;


### PR DESCRIPTION
A flag is stored a f64 internally but when a binary op (&) is performed it get's converted to a i32 and then the op is performed. But when compared (===) it's a f64 again. Which is now the negative value of itself because of the double conversion

This does not cause issues with negative numbers
![image](https://user-images.githubusercontent.com/63878374/234980367-ccf3a041-a1ad-437d-838a-f254a7bf4ad5.png)
