### PR TITLE
perf: Optimize `BitflagsN` Read & Write

### DIFF
--- a/src/bitflags/bitflags16.ts
+++ b/src/bitflags/bitflags16.ts
@@ -5,11 +5,11 @@ export class BitFlags16<
   I extends Record<string, number>,
   O = OutputRecord<I>,
 > extends SizedType<O> {
-  #record: I;
+  #recordEntries: Array<[string, number]>;
 
   constructor(record: I) {
     super(2, 2);
-    this.#record = record;
+    this.#recordEntries = Object.entries(record);
   }
 
   readPacked(dt: DataView, options: Options = { byteOffset: 0 }): O {
@@ -18,7 +18,7 @@ export class BitFlags16<
     const returnObject: Record<string, boolean> = {};
 
     const byteBag = dt.getUint16(options.byteOffset);
-    for (const { 0: key, 1: flag } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flag } of this.#recordEntries) {
       returnObject[key] = (byteBag & flag) === flag;
     }
 
@@ -36,7 +36,7 @@ export class BitFlags16<
 
     let flags = 0;
 
-    for (const { 0: key, 1: flagValue } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flagValue } of this.#recordEntries) {
       if (value[key as keyof O]) {
         flags |= flagValue;
       }

--- a/src/bitflags/bitflags32.ts
+++ b/src/bitflags/bitflags32.ts
@@ -5,11 +5,11 @@ export class BitFlags32<
   I extends Record<string, number>,
   O = OutputRecord<I>,
 > extends SizedType<O> {
-  #record: I;
+  #recordEntries: Array<[string, number]>;
 
   constructor(record: I) {
     super(4, 4);
-    this.#record = record;
+    this.#recordEntries = Object.entries(record);
   }
 
   readPacked(dt: DataView, options: Options = { byteOffset: 0 }): O {
@@ -18,7 +18,7 @@ export class BitFlags32<
     const returnObject: Record<string, boolean> = {};
 
     const byteBag = dt.getUint32(options.byteOffset);
-    for (const { 0: key, 1: flag } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flag } of this.#recordEntries) {
       returnObject[key] = (byteBag & flag) === flag;
     }
 
@@ -36,7 +36,7 @@ export class BitFlags32<
 
     let flags = 0;
 
-    for (const { 0: key, 1: flagValue } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flagValue } of this.#recordEntries) {
       if (value[key as keyof O]) {
         flags |= flagValue;
       }

--- a/src/bitflags/bitflags64.ts
+++ b/src/bitflags/bitflags64.ts
@@ -5,11 +5,11 @@ export class BitFlags64<
   I extends Record<string, bigint>,
   O = OutputRecord<I>,
 > extends SizedType<O> {
-  #record: I;
+  #recordEntries: Array<[string, bigint]>;
 
   constructor(record: I) {
     super(8, 8);
-    this.#record = record;
+    this.#recordEntries = Object.entries(record);
   }
 
   readPacked(dt: DataView, options: Options = { byteOffset: 0 }): O {
@@ -18,7 +18,7 @@ export class BitFlags64<
     const returnObject: Record<string, boolean> = {};
 
     const byteBag = dt.getBigUint64(options.byteOffset);
-    for (const { 0: key, 1: flag } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flag } of this.#recordEntries) {
       returnObject[key] = (byteBag & flag) === flag;
     }
 
@@ -36,7 +36,7 @@ export class BitFlags64<
 
     let flags = 0n;
 
-    for (const { 0: key, 1: flagValue } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flagValue } of this.#recordEntries) {
       if (value[key as keyof O]) {
         flags |= flagValue;
       }

--- a/src/bitflags/bitflags8.ts
+++ b/src/bitflags/bitflags8.ts
@@ -5,11 +5,11 @@ export class BitFlags8<
   I extends Record<string, number>,
   O = OutputRecord<I>,
 > extends SizedType<O> {
-  #record: I;
+  #recordEntries: Array<[string, number]>;
 
   constructor(record: I) {
     super(1, 1);
-    this.#record = record;
+    this.#recordEntries = Object.entries(record);
   }
 
   readPacked(dt: DataView, options: Options = { byteOffset: 0 }): O {
@@ -18,7 +18,7 @@ export class BitFlags8<
     const returnObject: Record<string, boolean> = {};
 
     const byteBag = dt.getUint8(options.byteOffset);
-    for (const { 0: key, 1: flag } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flag } of this.#recordEntries) {
       returnObject[key] = (byteBag & flag) === flag;
     }
 
@@ -36,7 +36,7 @@ export class BitFlags8<
 
     let flags = 0;
 
-    for (const { 0: key, 1: flagValue } of Object.entries(this.#record)) {
+    for (const { 0: key, 1: flagValue } of this.#recordEntries) {
       if (value[key as keyof O]) {
         flags |= flagValue;
       }


### PR DESCRIPTION
I only benchmarked bitflags 8 (against the branch #21 like last time)
Because most of this is the same code so it will all have similar performance gains

| Function | Gain |
| --- | --- |
| ReadPacked | 4x |
| Read | 3.6x |
| WritePacked | 5.5x |
| Write | 5.5x |

![image](https://github.com/denosaurs/byte_type/assets/63878374/9b304c0a-a040-4c4b-8085-efaeb169ae40)
