### PR TITLE
feat: Additional string codecs

### DIFF
--- a/src/string/fixed_length.ts
+++ b/src/string/fixed_length.ts
@@ -1,7 +1,7 @@
 import { type Options, SizedType } from "../types/mod.ts";
 import { TEXT_DECODER, TEXT_ENCODER } from "./_common.ts";
 
-export class FixedLength extends SizedType<string> {
+export class FixedLengthString extends SizedType<string> {
   constructor(length: number) {
     super(length, 1);
   }
@@ -38,5 +38,5 @@ export class FixedLength extends SizedType<string> {
   }
 }
 
-export const asciiChar = new FixedLength(1);
-export const utf8Char = new FixedLength(4);
+export const asciiChar = new FixedLengthString(1);
+export const utf8Char = new FixedLengthString(4);

--- a/src/string/prefixed_length.ts
+++ b/src/string/prefixed_length.ts
@@ -1,0 +1,65 @@
+import { UnsizedType, u8 } from "../mod.ts";
+import { Options } from "../types/_common.ts";
+import { TEXT_DECODER, TEXT_ENCODER } from "./_common.ts";
+
+export class PrefixedLengthString extends UnsizedType<string> {
+  #prefixCodec: UnsizedType<number>;
+
+  constructor(prefixCodec: UnsizedType<number> = u8) {
+    super(1);
+    this.#prefixCodec = prefixCodec;
+  }
+
+  writePacked(value: string, dt: DataView, options: Options = { byteOffset: 0 }): void {
+    this.#prefixCodec.writePacked(value.length, dt, options);
+
+    const view = new Uint8Array(
+      dt.buffer,
+      dt.byteOffset + options.byteOffset,
+      value.length
+    );
+
+    TEXT_ENCODER.encodeInto(value, view);
+    super.incrementOffset(options, value.length);
+  }
+
+  write(value: string, dt: DataView, options: Options = { byteOffset: 0 }): void {
+    this.#prefixCodec.write(value.length, dt, options);
+    super.alignOffset(options);
+
+    const view = new Uint8Array(
+      dt.buffer,
+      dt.byteLength + options.byteOffset,
+      value.length,
+    );
+
+    TEXT_ENCODER.encodeInto(value, view);
+    super.incrementOffset(options, value.length);
+  }
+
+  readPacked(dt: DataView, options: Options = { byteOffset: 0 }): string {
+    const length = this.#prefixCodec.readPacked(dt, options);
+    const view = new Uint8Array(
+      dt.buffer,
+      dt.byteOffset + options.byteOffset,
+      length,
+    );
+
+    super.incrementOffset(options, length);
+    return TEXT_DECODER.decode(view);
+  }
+
+  read(dt: DataView, options: Options = { byteOffset: 0 }): string {
+    const length = this.#prefixCodec.read(dt, options);
+    super.alignOffset(options);
+
+    const view = new Uint8Array(
+      dt.buffer,
+      dt.byteOffset + options.byteOffset,
+      length,
+    );
+
+    super.incrementOffset(options, length);
+    return TEXT_DECODER.decode(view);
+  }
+}

--- a/src/string/prefixed_length.ts
+++ b/src/string/prefixed_length.ts
@@ -1,8 +1,8 @@
-import { UnsizedType, u8 } from "../mod.ts";
+import { u8, UnsizedType } from "../mod.ts";
 import { Options } from "../types/_common.ts";
 import { TEXT_DECODER, TEXT_ENCODER } from "./_common.ts";
 
-export class PrefixedLengthString extends UnsizedType<string> {
+export class PrefixedString extends UnsizedType<string> {
   #prefixCodec: UnsizedType<number>;
 
   constructor(prefixCodec: UnsizedType<number> = u8) {
@@ -10,20 +10,28 @@ export class PrefixedLengthString extends UnsizedType<string> {
     this.#prefixCodec = prefixCodec;
   }
 
-  writePacked(value: string, dt: DataView, options: Options = { byteOffset: 0 }): void {
+  writePacked(
+    value: string,
+    dt: DataView,
+    options: Options = { byteOffset: 0 },
+  ): void {
     this.#prefixCodec.writePacked(value.length, dt, options);
 
     const view = new Uint8Array(
       dt.buffer,
       dt.byteOffset + options.byteOffset,
-      value.length
+      value.length,
     );
 
     TEXT_ENCODER.encodeInto(value, view);
     super.incrementOffset(options, value.length);
   }
 
-  write(value: string, dt: DataView, options: Options = { byteOffset: 0 }): void {
+  write(
+    value: string,
+    dt: DataView,
+    options: Options = { byteOffset: 0 },
+  ): void {
     this.#prefixCodec.write(value.length, dt, options);
     super.alignOffset(options);
 


### PR DESCRIPTION
Some strings are prefixed with some kind of length byte(s).
This is a generic class which by default uses a `u8` as length prefix but can use any `Unsized<number>` as prefix codec

No tests have been made or done. But it is relatively straight forward