### PR TITLE
feat: Sized compound types

### DIFF
--- a/benchmarks/arrays.ts
+++ b/benchmarks/arrays.ts
@@ -1,42 +1,42 @@
 import { ArrayType, SizedArrayType, u32 } from "../mod.ts";
 
 for (let i = 2; i < 10; i++) {
-    const codec = new ArrayType(u32, 1 << i);
-    const sizedCodec = new SizedArrayType(u32, 1 << i);
-    const data = new Array(1 << i).fill(0).map((_, i) => i);
-    const buff = new Uint32Array(1 << i).fill(0).map((_, i) => i);
-    const dt = new DataView(buff.buffer);
+  const codec = new ArrayType(u32, 1 << i);
+  const sizedCodec = new SizedArrayType(u32, 1 << i);
+  const data = new Array(1 << i).fill(0).map((_, i) => i);
+  const buff = new Uint32Array(1 << i).fill(0).map((_, i) => i);
+  const dt = new DataView(buff.buffer);
 
-    Deno.bench({
-        name: "Array (Read)",
-        baseline: true,
-        group: `read-${i}`,
-        fn: () => {
-            codec.readPacked(dt);
-        },
-    });
+  Deno.bench({
+    name: "Array (Read)",
+    baseline: true,
+    group: `read-${i}`,
+    fn: () => {
+      codec.readPacked(dt);
+    },
+  });
 
-    Deno.bench({
-        name: "Sized Array (Read)",
-        group: `read-${i}`,
-        fn: () => {
-            sizedCodec.readPacked(dt);
-        },
-    });
-    Deno.bench({
-        name: "Array (Write)",
-        baseline: true,
-        group: `write-${i}`,
-        fn: () => {
-            codec.writePacked(data, dt);
-        },
-    });
+  Deno.bench({
+    name: "Sized Array (Read)",
+    group: `read-${i}`,
+    fn: () => {
+      sizedCodec.readPacked(dt);
+    },
+  });
+  Deno.bench({
+    name: "Array (Write)",
+    baseline: true,
+    group: `write-${i}`,
+    fn: () => {
+      codec.writePacked(data, dt);
+    },
+  });
 
-    Deno.bench({
-        name: "Sized Array (Write)",
-        group: `write-${i}`,
-        fn: () => {
-            sizedCodec.writePacked(data, dt);
-        },
-    });
+  Deno.bench({
+    name: "Sized Array (Write)",
+    group: `write-${i}`,
+    fn: () => {
+      sizedCodec.writePacked(data, dt);
+    },
+  });
 }

--- a/benchmarks/arrays.ts
+++ b/benchmarks/arrays.ts
@@ -1,0 +1,42 @@
+import { ArrayType, SizedArrayType, u32 } from "../mod.ts";
+
+for (let i = 2; i < 10; i++) {
+    const codec = new ArrayType(u32, 1 << i);
+    const sizedCodec = new SizedArrayType(u32, 1 << i);
+    const data = new Array(1 << i).fill(0).map((_, i) => i);
+    const buff = new Uint32Array(1 << i).fill(0).map((_, i) => i);
+    const dt = new DataView(buff.buffer);
+
+    Deno.bench({
+        name: "Array (Read)",
+        baseline: true,
+        group: `read-${i}`,
+        fn: () => {
+            codec.readPacked(dt);
+        },
+    });
+
+    Deno.bench({
+        name: "Sized Array (Read)",
+        group: `read-${i}`,
+        fn: () => {
+            sizedCodec.readPacked(dt);
+        },
+    });
+    Deno.bench({
+        name: "Array (Write)",
+        baseline: true,
+        group: `write-${i}`,
+        fn: () => {
+            codec.writePacked(data, dt);
+        },
+    });
+
+    Deno.bench({
+        name: "Sized Array (Write)",
+        group: `write-${i}`,
+        fn: () => {
+            sizedCodec.writePacked(data, dt);
+        },
+    });
+}

--- a/benchmarks/big_struct.ts
+++ b/benchmarks/big_struct.ts
@@ -1,0 +1,148 @@
+import {
+  type InnerType,
+  SizedStruct,
+  Strings,
+  Struct,
+  u32,
+  u8,
+} from "../mod.ts";
+const innerDescriptor = {
+  name: new Strings.FixedLengthString(11),
+  hp: u8,
+  damage: u8,
+  shield: u32,
+};
+
+const baseDescriptor = {
+  handIndex: u8,
+  fieldIndex: u8,
+};
+
+const descriptor = {
+  ...baseDescriptor,
+  card: new Struct(innerDescriptor),
+};
+
+const sizedDescriptor = {
+  ...baseDescriptor,
+  card: new SizedStruct(innerDescriptor),
+};
+
+const codec = new Struct(descriptor);
+const sizedCodec = new SizedStruct(sizedDescriptor);
+
+const data: InnerType<typeof codec> = {
+  handIndex: 255,
+  fieldIndex: 255,
+  card: {
+    name: "InvalidCard",
+    hp: 255,
+    damage: 255,
+    shield: 255,
+  },
+};
+
+const object: InnerType<typeof codec> = {
+  handIndex: 0,
+  fieldIndex: 0,
+  card: {
+    name: "00000000000",
+    hp: 0,
+    damage: 0,
+    shield: 0,
+  },
+};
+
+const ARRAY_BUFFER = new ArrayBuffer(20);
+const DATA_VIEW = new DataView(ARRAY_BUFFER);
+const BIN_VIEW = new Uint8Array(ARRAY_BUFFER, 2, 11);
+const DECODER = new TextDecoder();
+const ENCODER = new TextEncoder();
+
+Deno.bench("no-op", () => {});
+
+Deno.bench({
+  baseline: true,
+  name: "object (Read)",
+  group: "read",
+  fn: () => {
+    object.handIndex;
+    object.fieldIndex;
+    object.card.name;
+    object.card.hp;
+    object.card.damage;
+    object.card.shield;
+  },
+});
+
+Deno.bench({
+  name: "Struct (Read)",
+  group: "read",
+  fn: () => {
+    codec.readPacked(DATA_VIEW);
+  },
+});
+
+Deno.bench({
+  name: "SizedStruct (Read)",
+  group: "read",
+  fn: () => {
+    sizedCodec.readPacked(DATA_VIEW);
+  },
+});
+
+Deno.bench({
+  name: "Primitives (Read)",
+  group: "read",
+  fn: () => {
+    DATA_VIEW.getUint8(0);
+    DATA_VIEW.getUint8(1);
+    DECODER.decode(BIN_VIEW);
+    DATA_VIEW.getUint8(13);
+    DATA_VIEW.getUint8(14);
+    DATA_VIEW.getUint32(16);
+  },
+});
+
+Deno.bench({
+  baseline: true,
+  name: "object (Write)",
+  group: "write",
+  fn: () => {
+    object.handIndex = 255;
+    object.fieldIndex = 255;
+    object.card.name = "InvalidCards";
+    object.card.hp = 255;
+    object.card.damage = 255;
+    object.card.shield = 255;
+  },
+});
+
+Deno.bench({
+  name: "Struct (Write)",
+  group: "write",
+  fn: () => {
+    codec.writePacked(data, DATA_VIEW);
+  },
+});
+
+Deno.bench({
+  name: "SizedStruct (Write)",
+  group: "write",
+  fn: () => {
+    sizedCodec.writePacked(data, DATA_VIEW);
+  },
+});
+
+Deno.bench({
+  name: "Primitives (Write)",
+  group: "write",
+  fn: () => {
+    DATA_VIEW.setUint8(0, 255);
+    DATA_VIEW.setUint8(1, 255);
+    ENCODER.encodeInto("InvalidCards", BIN_VIEW);
+    DATA_VIEW.setUint8(13, 255);
+    DATA_VIEW.setUint8(14, 255);
+    DATA_VIEW.setUint32(16, 255);
+  },
+});

--- a/benchmarks/struct.ts
+++ b/benchmarks/struct.ts
@@ -1,9 +1,15 @@
 import { Struct, u32 } from "../mod.ts";
+import { SizedStruct } from "../src/compound/sized_struct.ts";
 
 const data = new DataView(new ArrayBuffer(8));
 
 const object = { a: 123, b: 456 };
 const struct = new Struct({
+  a: u32,
+  b: u32,
+});
+
+const sizedStruct = new SizedStruct({
   a: u32,
   b: u32,
 });
@@ -25,6 +31,14 @@ Deno.bench({
   group: "read",
   fn: () => {
     struct.read(data);
+  },
+});
+
+Deno.bench({
+  name: "struct Sized",
+  group: "read",
+  fn: () => {
+    sizedStruct.read(data);
   },
 });
 
@@ -52,6 +66,17 @@ Deno.bench({
   group: "write",
   fn: () => {
     struct.write({
+      a: 0xffff,
+      b: 0xffff,
+    }, data);
+  },
+});
+
+Deno.bench({
+  name: "struct Sized",
+  group: "write",
+  fn: () => {
+    sizedStruct.write({
       a: 0xffff,
       b: 0xffff,
     }, data);

--- a/src/array/mod.ts
+++ b/src/array/mod.ts
@@ -1,3 +1,4 @@
 export * from "./array_buffer.ts";
 export * from "./array.ts";
 export * from "./typed_array.ts";
+export * from "./sized_array.ts";

--- a/src/array/sized_array.ts
+++ b/src/array/sized_array.ts
@@ -1,0 +1,31 @@
+import { type Options, SizedType } from "../types/mod.ts";
+import { ArrayType } from "./array.ts";
+
+export class SizedArrayType<T> extends SizedType<T[]> implements ArrayType<T> {
+  #inner: ArrayType<T>;
+
+  constructor(readonly type: SizedType<T>, readonly length: number) {
+    super(length * type.byteSize, type.byteAlignment);
+    this.#inner = new ArrayType(type, length);
+  }
+
+  readPacked(dt: DataView, options: Options = { byteOffset: 0 }): T[] {
+    return this.#inner.readPacked(dt, options);
+  }
+
+  read(dt: DataView, options: Options = { byteOffset: 0 }): T[] {
+    return this.#inner.read(dt, options);
+  }
+
+  writePacked(
+    value: T[],
+    dt: DataView,
+    options: Options = { byteOffset: 0 },
+  ): void {
+    this.#inner.writePacked(value, dt, options);
+  }
+
+  write(value: T[], dt: DataView, options: Options = { byteOffset: 0 }): void {
+    this.#inner.write(value, dt, options);
+  }
+}

--- a/src/compound/mod.ts
+++ b/src/compound/mod.ts
@@ -1,3 +1,4 @@
 export * from "./struct.ts";
 export * from "./tagged_union.ts";
 export * from "./tuple.ts";
+export * from "./sized_struct.ts";

--- a/src/compound/sized_struct.ts
+++ b/src/compound/sized_struct.ts
@@ -4,7 +4,7 @@ import { calculateTotalSize, getBiggestAlignment } from "../util.ts";
 type ReadFn<R> = (dt: DataView, options: Options) => R;
 type WriteFn<V> = (dt: DataView, options: Options, value: V) => void;
 
-const createProp = (key: string, method: string) =>
+const createRead = (key: string, method: string) =>
   `"${key}": ${key}.${method}(dt, options)`;
 
 const createWrite = (key: string, method: string) =>
@@ -26,7 +26,7 @@ function createFunc<V>(
   const seperator = !isWriter ? "," : "";
   const keys = Object.keys(input);
 
-  const mapFn = isWriter ? createWrite : createProp;
+  const mapFn = isWriter ? createWrite : createRead;
 
   const generatedCodec = keys.map((k) => mapFn(k, method)).join(seperator);
   const args = ["dt", "options"];

--- a/src/compound/sized_struct.ts
+++ b/src/compound/sized_struct.ts
@@ -1,0 +1,84 @@
+import { type InnerType, type Options, SizedType } from "../mod.ts";
+import { calculateTotalSize, getBiggestAlignment } from "../util.ts";
+
+type ReadFn<R> = (dt: DataView, options: Options) => R;
+type WriteFn<V> = (dt: DataView, options: Options, value: V) => void;
+
+const createProp = (key: string, method: string) =>
+  `"${key}": ${key}.${method}(dt, options)`;
+
+const createWrite = (key: string, method: string) =>
+  `${key}.${method}(value.${key}, dt, options);`;
+
+function createFunc<V, M extends `read${string}`>(
+  input: Record<string, SizedType<unknown>>,
+  method: M,
+): ReadFn<V>;
+function createFunc<V, M extends `write${string}`>(
+  input: Record<string, SizedType<unknown>>,
+  method: M,
+): WriteFn<V>;
+function createFunc<V>(
+  input: Record<string, SizedType<unknown>>,
+  method: string,
+): WriteFn<V> | ReadFn<V> {
+  const isWriter = method.startsWith("write");
+  const seperator = !isWriter ? "," : "";
+  const keys = Object.keys(input);
+
+  const mapFn = isWriter ? createWrite : createProp;
+
+  const generatedCodec = keys.map((k) => mapFn(k, method)).join(seperator);
+  const args = ["dt", "options"];
+  let body = `const { ${keys} } = this;`;
+
+  if (!isWriter) {
+    body += `return {${generatedCodec}}`;
+  } else {
+    body += `${generatedCodec}`;
+    args.push("value");
+  }
+
+  args.push(body);
+  return Function(...args).bind(input) as WriteFn<V> | ReadFn<V>;
+}
+
+export class SizedStruct<
+  T extends Record<string, SizedType<unknown>>,
+  V extends { [K in keyof T]: InnerType<T[K]> } = {
+    [K in keyof T]: InnerType<T[K]>;
+  },
+> extends SizedType<V> {
+  #readPacked: ReadFn<V>;
+  #read: ReadFn<V>;
+  #writePacked: WriteFn<V>;
+  #write: WriteFn<V>;
+
+  constructor(input: T) {
+    super(calculateTotalSize(input), getBiggestAlignment(input));
+    this.#readPacked = createFunc(input, "readPacked");
+    this.#read = createFunc(input, "read");
+    this.#writePacked = createFunc(input, "writePacked");
+    this.#write = createFunc(input, "write");
+  }
+
+  readPacked(dt: DataView, options: Options = { byteOffset: 0 }): V {
+    return this.#readPacked(dt, options);
+  }
+
+  read(dt: DataView, options: Options = { byteOffset: 0 }): V {
+    return this.#read(dt, options);
+  }
+
+  writePacked(
+    value: V,
+    dt: DataView,
+    options: Options = { byteOffset: 0 },
+  ): void {
+    this.#writePacked(dt, options, value);
+  }
+
+  write(value: V, dt: DataView, options: Options = { byteOffset: 0 }): void {
+    this.#write(dt, options, value);
+  }
+}

--- a/src/compound/sized_struct_test.ts
+++ b/src/compound/sized_struct_test.ts
@@ -3,44 +3,44 @@ import { assertEquals, assertThrows } from "../../test_deps.ts";
 import { SizedStruct } from "./mod.ts";
 
 Deno.test({
-    name: "Struct",
-    fn: async (t) => {
-        const ab = new ArrayBuffer(8);
-        const dt = new DataView(ab);
-        const type = new SizedStruct({ byte: u8, word: u32le });
+  name: "Struct",
+  fn: async (t) => {
+    const ab = new ArrayBuffer(8);
+    const dt = new DataView(ab);
+    const type = new SizedStruct({ byte: u8, word: u32le });
 
-        await t.step("Read", () => {
-            dt.setUint8(0, 127);
-            dt.setUint32(4, 255, true);
-            const result = type.read(dt);
-            assertEquals(result, { byte: 127, word: 255 });
-        });
+    await t.step("Read", () => {
+      dt.setUint8(0, 127);
+      dt.setUint32(4, 255, true);
+      const result = type.read(dt);
+      assertEquals(result, { byte: 127, word: 255 });
+    });
 
-        await t.step("Read Packed", () => {
-            dt.setUint8(0, 127);
-            dt.setUint32(1, 255, true);
-            const result = type.readPacked(dt);
-            assertEquals(result, { byte: 127, word: 255 });
-        });
+    await t.step("Read Packed", () => {
+      dt.setUint8(0, 127);
+      dt.setUint32(1, 255, true);
+      const result = type.readPacked(dt);
+      assertEquals(result, { byte: 127, word: 255 });
+    });
 
-        dt.setBigUint64(0, 0n);
+    dt.setBigUint64(0, 0n);
 
-        await t.step("Write", () => {
-            type.write({ byte: 255, word: 127 }, dt);
-            assertEquals(dt.getUint32(0, true), 255);
-            assertEquals(dt.getUint32(4, true), 127);
-        });
+    await t.step("Write", () => {
+      type.write({ byte: 255, word: 127 }, dt);
+      assertEquals(dt.getUint32(0, true), 255);
+      assertEquals(dt.getUint32(4, true), 127);
+    });
 
-        await t.step("Write Packed", () => {
-            type.writePacked({ byte: 255, word: 127 }, dt);
-            assertEquals(dt.getUint8(0), 255);
-            assertEquals(dt.getUint32(1, true), 127);
-        });
+    await t.step("Write Packed", () => {
+      type.writePacked({ byte: 255, word: 127 }, dt);
+      assertEquals(dt.getUint8(0), 255);
+      assertEquals(dt.getUint32(1, true), 127);
+    });
 
-        await t.step("OOB Read", () => {
-            assertThrows(() => {
-                type.read(dt, { byteOffset: 9 });
-            }, RangeError);
-        });
-    },
+    await t.step("OOB Read", () => {
+      assertThrows(() => {
+        type.read(dt, { byteOffset: 9 });
+      }, RangeError);
+    });
+  },
 });

--- a/src/compound/sized_struct_test.ts
+++ b/src/compound/sized_struct_test.ts
@@ -1,0 +1,46 @@
+import { u32le, u8 } from "../mod.ts";
+import { assertEquals, assertThrows } from "../../test_deps.ts";
+import { SizedStruct } from "./mod.ts";
+
+Deno.test({
+    name: "Struct",
+    fn: async (t) => {
+        const ab = new ArrayBuffer(8);
+        const dt = new DataView(ab);
+        const type = new SizedStruct({ byte: u8, word: u32le });
+
+        await t.step("Read", () => {
+            dt.setUint8(0, 127);
+            dt.setUint32(4, 255, true);
+            const result = type.read(dt);
+            assertEquals(result, { byte: 127, word: 255 });
+        });
+
+        await t.step("Read Packed", () => {
+            dt.setUint8(0, 127);
+            dt.setUint32(1, 255, true);
+            const result = type.readPacked(dt);
+            assertEquals(result, { byte: 127, word: 255 });
+        });
+
+        dt.setBigUint64(0, 0n);
+
+        await t.step("Write", () => {
+            type.write({ byte: 255, word: 127 }, dt);
+            assertEquals(dt.getUint32(0, true), 255);
+            assertEquals(dt.getUint32(4, true), 127);
+        });
+
+        await t.step("Write Packed", () => {
+            type.writePacked({ byte: 255, word: 127 }, dt);
+            assertEquals(dt.getUint8(0), 255);
+            assertEquals(dt.getUint32(1, true), 127);
+        });
+
+        await t.step("OOB Read", () => {
+            assertThrows(() => {
+                type.read(dt, { byteOffset: 9 });
+            }, RangeError);
+        });
+    },
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,8 @@ export const getBiggestAlignment = (
   Object.values(input)
     .reduce((acc, x) => Math.max(acc, x.byteAlignment), 0);
 
-export const calculateTotalSize = (input: ArrayOrRecord<SizedType<unknown>>) =>
+export const calculateTotalSize = (
+  input: ArrayOrRecord<SizedType<unknown>>,
+): number =>
   Object.values(input)
     .reduce((acc, x) => acc + x.byteSize, 0);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { UnsizedType } from "./mod.ts";
+import type { SizedType, UnsizedType } from "./mod.ts";
 
 /**
  * The endianess of your machine, true if little endian and false if big endian.
@@ -21,3 +21,7 @@ export const getBiggestAlignment = (
 ): number =>
   Object.values(input)
     .reduce((acc, x) => Math.max(acc, x.byteAlignment), 0);
+
+export const calculateTotalSize = (input: ArrayOrRecord<SizedType<unknown>>) =>
+  Object.values(input)
+    .reduce((acc, x) => acc + x.byteSize, 0);


### PR DESCRIPTION
This adds `SizedArray<T>` and `SizedStruct<T>`. `SizedStruct<T>` get's a optimized read / write function when being created which means it is about twice as fast as `Struct` in read operations where all types have a static size at the time of construction.

`SizedArray<T>` is a special addition. It has no optimizations itself but allows the `SizedStruct<T>` optimization to work for arrays inside of `Struct`