### PR TITLE
Feat(Struct): Make JIT struct optional

### DIFF
--- a/benchmarks/big_struct.ts
+++ b/benchmarks/big_struct.ts
@@ -18,18 +18,20 @@ const baseDescriptor = {
   fieldIndex: u8,
 };
 
-const descriptor = {
+const codec = new Struct({
   ...baseDescriptor,
   card: new Struct(innerDescriptor),
-};
+});
 
-const sizedDescriptor = {
+const sizedJITCodec = new SizedStruct({
   ...baseDescriptor,
   card: new SizedStruct(innerDescriptor),
-};
+});
 
-const codec = new Struct(descriptor);
-const sizedCodec = new SizedStruct(sizedDescriptor);
+const sizedCodec = new SizedStruct({
+  ...baseDescriptor,
+  card: new SizedStruct(innerDescriptor, false),
+}, false);
 
 const data: InnerType<typeof codec> = {
   handIndex: 255,
@@ -55,6 +57,14 @@ Deno.bench({
   group: "read",
   fn: () => {
     codec.readPacked(DATA_VIEW);
+  },
+});
+
+Deno.bench({
+  name: "SizedStruct JIT (Read)",
+  group: "read",
+  fn: () => {
+    sizedJITCodec.readPacked(DATA_VIEW);
   },
 });
 
@@ -89,6 +99,14 @@ Deno.bench({
   group: "write",
   fn: () => {
     codec.writePacked(data, DATA_VIEW);
+  },
+});
+
+Deno.bench({
+  name: "SizedStruct JIT (Write)",
+  group: "write",
+  fn: () => {
+    sizedJITCodec.writePacked(data, DATA_VIEW);
   },
 });
 

--- a/src/compound/sized_struct.ts
+++ b/src/compound/sized_struct.ts
@@ -18,8 +18,7 @@ function createReadMethod<V>(
   const method = isPacked ? "readPacked" : "read";
   const keys = Object.keys(input);
 
-  const generatedCodec = keys.map((k) => createRead(k, method));
-
+  const generatedCodec = keys.map((k) => createRead(k, method)).join(",\n");
   const body = `const { ${keys} } = this;\nreturn { ${generatedCodec} }`;
 
   return Function("dt", "options", body).bind(input);
@@ -32,9 +31,9 @@ function createWriteMethod<V>(
   const method = isPacked ? "writePacked" : "write";
   const keys = Object.keys(input);
 
-  const generatedCodec = keys.map((k) => createWrite(k, method));
+  const generatedCodec = keys.map((k) => createWrite(k, method)).join("\n");
+  const body = `const { ${keys} } = this;\n${generatedCodec}`;
 
-  const body = `const { ${keys} } = this;\nreturn { ${generatedCodec} }`;
   return Function("value", "dt", "options", body).bind(input);
 }
 
@@ -55,7 +54,7 @@ export class SizedStruct<
         read: createReadMethod(input, false),
         readPacked: createReadMethod(input, true),
         write: createWriteMethod(input, false),
-        writePacked: createWriteMethod(input, false),
+        writePacked: createWriteMethod(input, true),
       };
     } else {
       this.#inner = new Struct(input);

--- a/src/compound/sized_struct_test.ts
+++ b/src/compound/sized_struct_test.ts
@@ -3,11 +3,54 @@ import { assertEquals, assertThrows } from "../../test_deps.ts";
 import { SizedStruct } from "./mod.ts";
 
 Deno.test({
-  name: "Struct",
+  name: "Sized Struct JIT",
   fn: async (t) => {
     const ab = new ArrayBuffer(8);
     const dt = new DataView(ab);
     const type = new SizedStruct({ byte: u8, word: u32le });
+
+    await t.step("Read", () => {
+      dt.setUint8(0, 127);
+      dt.setUint32(4, 255, true);
+      const result = type.read(dt);
+      assertEquals(result, { byte: 127, word: 255 });
+    });
+
+    await t.step("Read Packed", () => {
+      dt.setUint8(0, 127);
+      dt.setUint32(1, 255, true);
+      const result = type.readPacked(dt);
+      assertEquals(result, { byte: 127, word: 255 });
+    });
+
+    dt.setBigUint64(0, 0n);
+
+    await t.step("Write", () => {
+      type.write({ byte: 255, word: 127 }, dt);
+      assertEquals(dt.getUint32(0, true), 255);
+      assertEquals(dt.getUint32(4, true), 127);
+    });
+
+    await t.step("Write Packed", () => {
+      type.writePacked({ byte: 255, word: 127 }, dt);
+      assertEquals(dt.getUint8(0), 255);
+      assertEquals(dt.getUint32(1, true), 127);
+    });
+
+    await t.step("OOB Read", () => {
+      assertThrows(() => {
+        type.read(dt, { byteOffset: 9 });
+      }, RangeError);
+    });
+  },
+});
+
+Deno.test({
+  name: "Sized Struct NON-JIT",
+  fn: async (t) => {
+    const ab = new ArrayBuffer(8);
+    const dt = new DataView(ab);
+    const type = new SizedStruct({ byte: u8, word: u32le }, false);
 
     await t.step("Read", () => {
       dt.setUint8(0, 127);


### PR DESCRIPTION
Right now the only time you can use a `SizedStruct` is when you can JIT compile functions, which is not always the case in some runtimes. Therefore I implemented a alternative for when you don't want to JIT compile anything but just want to narrow the type to `Sized` only